### PR TITLE
Validators can now return which rule failed

### DIFF
--- a/src/Errors/ValidatorErrorBag.php
+++ b/src/Errors/ValidatorErrorBag.php
@@ -26,12 +26,11 @@ class ValidatorErrorBag
     public function getErrors(?string $field = null): array
     {
         // indexed array
-        if (!array_key_exists($field, $this->errors)
+        if (!($field !== null && array_key_exists($field, $this->errors))
             && array_keys($this->errors) === range(
                 min(array_keys($this->errors)),
                 max(array_keys($this->errors))
-            ))
-        {
+            )) {
             $filteredErrors = $this->errors;
             foreach ($this->errors as $index => $fieldErrors) {
                 foreach ($fieldErrors as $key => $_) {
@@ -47,8 +46,11 @@ class ValidatorErrorBag
         return $field ? ($this->errors[$field] ?? []) : $this->errors;
     }
 
-    public function getFirstError(?string $field = null, ?int $index = null, bool $fullDetails = false): string|array|null
-    {
+    public function getFirstError(
+        ?string $field = null,
+        ?int $index = null,
+        bool $fullDetails = false
+    ): string|array|null {
         // For provided Index and field
         if ($index !== null) {
             // Index is not exists return null

--- a/src/Errors/ValidatorErrorBag.php
+++ b/src/Errors/ValidatorErrorBag.php
@@ -8,21 +8,46 @@ class ValidatorErrorBag
 {
     protected array $errors = [];
 
-    public function addError(string $field, string $message, ?int $index = null): void
+    public function addError(string $field, string $message, ?int $index = null, ?string $rule = null): void
     {
+        $errorData = ['message' => $message];
+
+        if ($rule !== null) {
+            $errorData['rule'] = $rule;
+        }
+
         if ($index !== null) {
-            $this->errors[$index][$field][] = $message;
+            $this->errors[$index][$field][] = $errorData;
         } else {
-            $this->errors[$field][] = $message;
+            $this->errors[$field][] = $errorData;
         }
     }
 
     public function getErrors(?string $field = null): array
     {
+        // indexed array
+        if (!array_key_exists($field, $this->errors)
+            && array_keys($this->errors) === range(
+                min(array_keys($this->errors)),
+                max(array_keys($this->errors))
+            ))
+        {
+            $filteredErrors = $this->errors;
+            foreach ($this->errors as $index => $fieldErrors) {
+                foreach ($fieldErrors as $key => $_) {
+                    if ($key !== $field) {
+                        unset($filteredErrors[$index][$key]);
+                    }
+                }
+            }
+
+            return $filteredErrors;
+        }
+
         return $field ? ($this->errors[$field] ?? []) : $this->errors;
     }
 
-    public function getFirstError(?string $field = null, ?int $index = null): ?string
+    public function getFirstError(?string $field = null, ?int $index = null, bool $fullDetails = false): string|array|null
     {
         // For provided Index and field
         if ($index !== null) {
@@ -33,12 +58,16 @@ class ValidatorErrorBag
 
             // Index and field are provided
             if ($field !== null) {
-                return $this->errors[$index][$field][0] ?? null;
+                return $fullDetails
+                ? (reset($this->errors[$index][$field]) ?? null)
+                : ($this->errors[$index][$field][0]['message'] ?? null);
             }
 
             // filed is not provided, return first error from index from any field
             foreach ($this->errors[$index] ?? [] as $message) {
-                return $message[0] ?? null;
+                return $fullDetails
+                ? (reset($message) ?? null)
+                : ($message[0]['message'] ?? null);
             }
         }
 
@@ -46,7 +75,9 @@ class ValidatorErrorBag
         if ($field !== null) {
             // if field exists and is not list
             if (isset($this->errors[$field]) && !array_is_list($this->errors[$field])) {
-                return $this->errors[$field][0] ?? null;
+                return $fullDetails
+                ? (reset($this->errors[$field]) ?? null)
+                : ($this->errors[$field][0]['message'] ?? null);
             }
 
             if (!isset($this->errors[$field])) {
@@ -56,7 +87,9 @@ class ValidatorErrorBag
                 // try iterate ofver array and check if filed exists in member arrays
                 foreach ($this->errors as $fieldErrors) {
                     if (isset($fieldErrors[$field])) {
-                        return $fieldErrors[$field][0] ?? null;
+                        return $fullDetails
+                        ? (reset($fieldErrors[$field]) ?? null)
+                        : ($fieldErrors[$field][0]['message'] ?? null);
                     }
                 }
 
@@ -67,16 +100,16 @@ class ValidatorErrorBag
 
         // general case: get first error from any field (entrie set)
         foreach ($this->errors as $_ => $fieldErrors) {
-            if (is_array($fieldErrors)) {
-                foreach ($fieldErrors as $errorGroup) {
-                    if (is_array($errorGroup)) {
-                        return $errorGroup[0] ?? null;
-                    } else {
-                        return $errorGroup;
-                    }
+            foreach ($fieldErrors as $errorGroup) {
+                if (array_is_list($errorGroup)) {
+                    return $fullDetails
+                    ? ($errorGroup[0] ?? null)
+                    : ($errorGroup[0]['message'] ?? null);
                 }
-            } else {
-                return $fieldErrors;
+
+                return $fullDetails
+                    ? ($errorGroup ?? null)
+                    : ($errorGroup['message'] ?? null);
             }
         }
 

--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -73,6 +73,8 @@ class BaseValidator
                 // if there is attribute agains which we want to validate
                 $property->setAccessible(true);
                 $value = $property->getValue($model);
+
+                /** @var ValidatorAttributeInterface $a */
                 $a = $attribute->newInstance();
 
                 if (!$a->validate($value)) {
@@ -92,7 +94,6 @@ class BaseValidator
                         return $errors;
                     }
                 }
-                
             }
         }
 

--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -79,7 +79,8 @@ class BaseValidator
                     $errors->addError(
                         $property->getName(),
                         'Property ' . $property->getName() . ' is required',
-                        index: $index
+                        index: $index,
+                        rule: $attribute->getName()
                     );
 
                     // fail on first error

--- a/tests/FileImportTest.php
+++ b/tests/FileImportTest.php
@@ -108,6 +108,16 @@ class FileImportTest extends TestCase
             $this->assertEquals('Property colA is required', $e->getFirstError()); // first error for any field
             $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA')); // first error for field colA
             $this->assertEquals(null, $e->getFirstError(field: 'colB')); // field colB -> there should be no error
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(field: 'colA', fullDetails: true));
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(fullDetails: true));
         }
     }
 
@@ -123,6 +133,8 @@ class FileImportTest extends TestCase
             $this->assertEquals('Property colA is required', $e->getFirstError()); // first error for any field
             $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA')); // first error for field colA
             $this->assertEquals(null, $e->getFirstError(field: 'colB')); // field colB -> there should be no error
+
+            $this->assertEquals(null, $e->getFirstError(field: 'colB', fullDetails: true));
         }
     }
 
@@ -132,7 +144,7 @@ class FileImportTest extends TestCase
         $baseValidator = new BaseValidator(failFast: true, throwException: false);
 
         /** @var ValidatorErrorBag $e */
-        $e = $baseValidator->validateMany($this->modelArray, rule: NotEmpty::class);
+        $e = $baseValidator->validateMany($this->modelArray);
 
         if ($e->hasErrors()) {
             $this->assertEquals('Property colA is required', $e->getFirstError()); // return any first error
@@ -140,6 +152,26 @@ class FileImportTest extends TestCase
             $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA')); // return first error for field colA in any index
             $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA', index: 2)); // return first error for field colA on index 2
             $this->assertEquals(null, $e->getFirstError(index: 1)); // row 1 should be valid
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(index: 2, field: 'colA', fullDetails: true));
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(fullDetails: true));
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(field: 'colA', fullDetails: true));
+
+            $this->assertEquals([
+                'message' => 'Property colA is required',
+                'rule' => 'MayMeow\ExcelImporter\Attributes\NotEmpty'
+            ], $e->getFirstError(index: 2, fullDetails: true));
         }
     }
 

--- a/tests/FileImportTest.php
+++ b/tests/FileImportTest.php
@@ -110,4 +110,38 @@ class FileImportTest extends TestCase
             $this->assertEquals(null, $e->getFirstError(field: 'colB')); // field colB -> there should be no error
         }
     }
+
+    /** @test */
+    public function testValidationForAllRules()
+    {
+        $baseValidator = new BaseValidator(failFast: true, throwException: false);
+
+        // do not define rule here
+        $e = $baseValidator->validate($this->modelArray[2]);
+
+        if ($e->hasErrors()) {
+            $this->assertEquals('Property colA is required', $e->getFirstError()); // first error for any field
+            $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA')); // first error for field colA
+            $this->assertEquals(null, $e->getFirstError(field: 'colB')); // field colB -> there should be no error
+        }
+    }
+
+    /** @test */
+    public function testValidatorForManyForAllRules()
+    {
+        $baseValidator = new BaseValidator(failFast: true, throwException: false);
+
+        /** @var ValidatorErrorBag $e */
+        $e = $baseValidator->validateMany($this->modelArray, rule: NotEmpty::class);
+
+        if ($e->hasErrors()) {
+            $this->assertEquals('Property colA is required', $e->getFirstError()); // return any first error
+            $this->assertEquals('Property colA is required', $e->getFirstError(index: 2)); // return any first error on index 2
+            $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA')); // return first error for field colA in any index
+            $this->assertEquals('Property colA is required', $e->getFirstError(field: 'colA', index: 2)); // return first error for field colA on index 2
+            $this->assertEquals(null, $e->getFirstError(index: 1)); // row 1 should be valid
+        }
+    }
+
+
 }


### PR DESCRIPTION
closes #23 

Reasons for this pull request:

- Error bag now contains infomation about which rule is failing. 
  - Method `getFirstError` can return these details by defining `fullDetails: true`
- Method `getErrors` wil return all errors also when validator runs on array of objects
- Method `validate` and `validateMany` now allows empty `rule` property
  - when `rule` is empty it will look for all attributes that implement `ValidatorAttributeInterface`