### PR TITLE
Attributes now allows to have empty message

### DIFF
--- a/src/Attributes/BaseValidatorAttribute.php
+++ b/src/Attributes/BaseValidatorAttribute.php
@@ -4,7 +4,7 @@ namespace MayMeow\ExcelImporter\Attributes;
 
 abstract class BaseValidatorAttribute
 {
-    public function __construct(protected ?string $message)
+    public function __construct(protected ?string $message = null)
     {
         //
     }

--- a/tests/Models/TestingModel.php
+++ b/tests/Models/TestingModel.php
@@ -14,6 +14,7 @@ class TestingModel extends BaseModel
     protected string $colA;
 
     #[Column('B')]
+    #[NotEmpty] // allow empty message
     protected string $colB;
 
     #[Column('C')]


### PR DESCRIPTION
- property `message` for attributes can now be empty. in that case the default message generated by validation will be stored

closes #24 